### PR TITLE
[suggestion] Adding a demo section

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,10 @@ To run the test on 200M SIFT subset:
 
 The size of the bigann subset (in millions) is controlled by the variable **subset_size_milllions** hardcoded in **sift_1b.cpp**.
 
+### HNSW example demos
 
+- Visual search engine for 1M amazon products (MXNet + HNSW): [website](https://thomasdelteil.github.io/VisualSearch_MXNet/), [code](https://github.com/ThomasDelteil/VisualSearch_MXNet), demo by [@ThomasDelteil](https://github.com/ThomasDelteil)
 
-References:
+### References
+
 Malkov, Yu A., and D. A. Yashunin. "Efficient and robust approximate nearest neighbor search using Hierarchical Navigable Small World graphs." arXiv preprint arXiv:1603.09320 (2016). https://arxiv.org/abs/1603.09320


### PR DESCRIPTION
Thanks for the great library, I used it to create a demo website to showcase how you can build a Visual Search engine using MXNet and HNSW: https://thomasdelteil.github.io/VisualSearch_MXNet/

I was thinking it could be a good idea to add a demo section in order to point to the website to provide other users with ideas and maybe inspiration. It would be great to also see how other users are using this library if there are any other demos out there.

If such a section is not appropriate feel free to close the PR, I really won't be offended 😄 