### PR TITLE
hnswlib/visited_list_pool.h: use delete[] to match new[]

### DIFF
--- a/hnswlib/visited_list_pool.h
+++ b/hnswlib/visited_list_pool.h
@@ -26,7 +26,7 @@ namespace hnswlib {
             }
         };
 
-        ~VisitedList() { delete mass; }
+        ~VisitedList() { delete[] mass; }
     };
 ///////////////////////////////////////////////////////////
 //


### PR DESCRIPTION
Trivial patch to fix valgrind warning about mismatched delete / new.

Details of warning previously seen:
```
==16753== Mismatched free() / delete / delete []
==16753==    at 0x4C2D2DB: operator delete(void*) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==16753==    by 0x10B1B0: hnswlib::VisitedList::~VisitedList() (in /«rootdir»/hnsw_test)
==16753==    by 0x10B456: hnswlib::VisitedListPool::~VisitedListPool() (in /«rootdir»/hnsw_test)
==16753==    by 0x10BE9C: hnswlib::HierarchicalNSW<float>::~HierarchicalNSW() (in /«rootdir»/hnsw_test)
==16753==    by 0x10BEF9: hnswlib::HierarchicalNSW<float>::~HierarchicalNSW() (in /«rootdir»/hnsw_test)
==16753==    by 0x10ACE7: main (in /«rootdir»/hnsw_test)
==16753==  Address 0x5bde1e0 is 0 bytes inside a block of size 20,000 alloc'd
==16753==    at 0x4C2C93F: operator new[](unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==16753==    by 0x10B121: hnswlib::VisitedList::VisitedList(int) (in /«rootdir»/hnsw_test)
==16753==    by 0x10B26D: hnswlib::VisitedListPool::VisitedListPool(int, int) (in /«rootdir»/hnsw_test)
==16753==    by 0x10C9F7: hnswlib::HierarchicalNSW<float>::loadIndex(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, hnswlib::SpaceInterface<float>*) (in /«rootdir»/hnsw_test)  
==16753==    by 0x10B89D: hnswlib::HierarchicalNSW<float>::HierarchicalNSW(hnswlib::SpaceInterface<float>*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) (in /«rootdir»/hnsw_test)
==16753==    by 0x10AC0D: main (in /«rootdir»/hnsw_test)
```