### PR TITLE
hnswlib/hnswalg.h: increase linked list element size by 1

### DIFF
--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -612,8 +612,8 @@ namespace hnswlib {
 
 
             if (curlevel) {
-                linkLists_[cur_c] = (char *) malloc(size_links_per_element_ * curlevel);
-                memset(linkLists_[cur_c], 0, size_links_per_element_ * curlevel);
+                linkLists_[cur_c] = (char *) malloc(size_links_per_element_ * curlevel + 1);
+                memset(linkLists_[cur_c], 0, size_links_per_element_ * curlevel + 1);
             }
             if (currObj != -1) {
 


### PR DESCRIPTION
This prevents an `Invalid read of size 4` in the `searchBaseLayer`
(hnswalg.h:194).