### PR TITLE
Remove unnecessary semi-colons

### DIFF
--- a/hnswlib/space_ip.h
+++ b/hnswlib/space_ip.h
@@ -1,4 +1,3 @@
-
 #pragma once
 #ifdef _MSC_VER
 #include <intrin.h>
@@ -32,7 +31,7 @@ namespace hnswlib {
         }
         return (1.0f - res);
 
-    };
+    }
 
 
     static float
@@ -130,7 +129,7 @@ namespace hnswlib {
 
         return 1.0f - sum;
 #endif
-    };
+    }
     static float
     InnerProductSIMD16Ext(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
         float PORTABLE_ALIGN32 TmpRes[8];
@@ -206,7 +205,7 @@ namespace hnswlib {
 
         return 1.0f - sum;
 #endif
-    };
+    }
 
 
     class InnerProductSpace : public SpaceInterface<float> {
@@ -240,4 +239,4 @@ namespace hnswlib {
     };
 
 
-};
+}

--- a/hnswlib/space_l2.h
+++ b/hnswlib/space_l2.h
@@ -34,7 +34,7 @@ namespace hnswlib {
         }
         return (res);
 
-    };
+    }
 
 
     static float
@@ -117,7 +117,7 @@ namespace hnswlib {
 
         return (res);
 #endif
-    };
+    }
 
 
     static float
@@ -148,7 +148,7 @@ namespace hnswlib {
         float res = TmpRes[0] + TmpRes[1] + TmpRes[2] + TmpRes[3];
 
         return (res);
-    };
+    }
 
     class L2Space : public SpaceInterface<float> {
 
@@ -216,7 +216,7 @@ namespace hnswlib {
 
         return (res);
 
-    };
+    }
 
     class L2SpaceI : public SpaceInterface<int> {
 
@@ -245,4 +245,4 @@ namespace hnswlib {
     };
 
 
-};
+}


### PR DESCRIPTION
A fix for the trivial issue #67. Recent changes to the [R devtools package](https://cran.r-project.org/package=devtools) defaults causes these warnings to appear when building [R bindings](https://github.com/jlmelville/rcpphnsw) to hnsw.